### PR TITLE
Revert back to using ffmpeg as video and audio need to be combined and encoded

### DIFF
--- a/core/driver.py
+++ b/core/driver.py
@@ -13,9 +13,9 @@ import os.path
 import sys
 from datetime import date
 
+import ffmpeg
 import pytube
 import vimeo
-from moviepy.video.io.ffmpeg_tools import ffmpeg_merge_video_audio, ffmpeg_extract_subclip
 from pytube import YouTube
 from pytube.cli import on_progress
 
@@ -183,7 +183,9 @@ def join_resource(video_path: str, audio_path: str, output_path: str) -> None:
     :param output_path:
     :return:
     """
-    ffmpeg_merge_video_audio(video_path, audio_path, output_path)
+    input_video = ffmpeg.input(video_path)
+    input_audio = ffmpeg.input(audio_path)
+    ffmpeg.output(input_video, input_audio, output_path, vcodec='copy').run()
 
 
 def trim_resource(
@@ -199,11 +201,14 @@ def trim_resource(
     :param end_time_in_sec:
     :return:
     """
-    ffmpeg_extract_subclip(
-        input_path,
-        start_time_in_sec,
-        end_time_in_sec,
-        output_path)
+    input_video = ffmpeg.input(input_path)
+    ffmpeg.output(
+        input_video,
+        output_path,
+        ss=start_time_in_sec,
+        t=end_time_in_sec,
+        vcodec='copy',
+        acodec='copy').run()
 
 
 def upload_video_to_vimeo(

--- a/gui/ui.py
+++ b/gui/ui.py
@@ -277,7 +277,7 @@ class VimeoUploader:
                 driver.process(video_config)
                 messagebox.showinfo(
                     "Upload status",
-                    f"Finished uploading video with ID {video_config.video_id}")
+                    f"Finished uploading video to Vimeo for YouTube video with ID [{video_config.video_id}]")
             except vimeo.exceptions.VideoUploadFailure:
                 messagebox.showerror(
                     'Error', 'Failed to process the video with input configuration!')


### PR DESCRIPTION
Re-use `ffmpeg` library as video needs to be encoded. It looks like simply joining and trimming video/audio sources causes out of sync issues on Vimeo.